### PR TITLE
no image preview for image fields in object

### DIFF
--- a/src/SimpleRESTAdapterBundle/Provider/AssetProvider.php
+++ b/src/SimpleRESTAdapterBundle/Provider/AssetProvider.php
@@ -93,7 +93,7 @@ final class AssetProvider implements ProviderInterface
      * @return array<string, array>
      * @throws Exception
      */
-    private function getBinaryDataValues(Asset $asset, ConfigReader $reader): array
+    public function getBinaryDataValues(Asset $asset, ConfigReader $reader): array
     {
         $data = [];
 

--- a/src/SimpleRESTAdapterBundle/Resources/config/services/data_collectors.yml
+++ b/src/SimpleRESTAdapterBundle/Resources/config/services/data_collectors.yml
@@ -16,6 +16,7 @@ services:
     CIHub\Bundle\SimpleRESTAdapterBundle\DataCollector\ImageDataCollector:
         arguments:
             - '@router.default'
+            - '@CIHub\Bundle\SimpleRESTAdapterBundle\Provider\AssetProvider'
         tags:
             - { name: 'simple_rest_adapter.data_collector', priority: 30 }
 


### PR DESCRIPTION
use the same code for collection binaryData for images in object as for collection binaryData in assets

fixes: #9 

I was unfortunately not able to test it fully, but it worked in my environment.